### PR TITLE
Fix _putenv putting garbage in the environment

### DIFF
--- a/wix/overlays/runtime/__init__.py
+++ b/wix/overlays/runtime/__init__.py
@@ -6,6 +6,7 @@ import sys
 
 from ctypes import windll
 from ctypes import cdll
+from ctypes import c_wchar_p
 from ctypes.util import find_msvcrt
 
 
@@ -33,7 +34,7 @@ def _putenv(name, value):
 
     # Update the copy maintained by Windows (so SysInternals Process Explorer sees it)
     try:
-        result = windll.kernel32.SetEnvironmentVariableW(name, value)
+        result = windll.kernel32.SetEnvironmentVariableW(c_wchar_p(name), c_wchar_p(value))
         if result == 0: raise Warning
     except Exception:
         if sys.flags.verbose:


### PR DESCRIPTION
We need to use c_wchar_p or Unicode strings when calling wide versions of api calls through ctypes.

Before patch:
![env](https://cloud.githubusercontent.com/assets/308129/16617097/f2555d94-4381-11e6-8298-db71a42d3076.png)

After patch:
![image](https://cloud.githubusercontent.com/assets/308129/16617139/3bddc6fe-4382-11e6-9a06-753a61991161.png)

This issue also causes cygwin processes to fail when launching them from python with e.g. subprocess. Without patch:
![image](https://cloud.githubusercontent.com/assets/308129/16617387/b6b77fc2-4383-11e6-9fa3-3740e53dbc8a.png)

With patch:
![image](https://cloud.githubusercontent.com/assets/308129/16617408/d127210a-4383-11e6-8c49-9d04cffec986.png)
